### PR TITLE
feat: Configurable attempt retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ curl -X POST http://localhost:8080/tasks \
 Send a GET to `/tasks/list` (requires `X-API-Key` header if enabled):
 
 ```bash
-curl -X GET http://localhost:8080/tasks/list \
+curl -X GET http://localhost:8080/tasks \
   -H "X-API-Key: your-secret"
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ curl -X POST http://localhost:8080/tasks \
 - `url`: Where to POST
 - `headers`: (optional) Map of HTTP headers
 - `payload`: (optional) Anything: JSON, string, bytes, form data, etc.
+- `retries`: (optional) Number of retries.
+- `retries_interval`: (optional) Wait time between retries in milliseconds (default: 2000).
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ curl -X POST http://localhost:8080/tasks \
 - `headers`: (optional) Map of HTTP headers
 - `payload`: (optional) Anything: JSON, string, bytes, form data, etc.
 - `retries`: (optional) Number of retries.
-- `retries_interval`: (optional) Wait time between retries in milliseconds (default: 2000).
+- `retry_interval`: (optional) Wait time between retries in milliseconds (default: 2000).
 
 #### Examples
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -47,6 +48,12 @@ func (e *Executor) Execute(task scheduler.Task) error {
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	_, err = e.client.Do(req)
-	return err
+	res, err := e.client.Do(req)
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+	defer res.Body.Close()
+
+	return nil
 }

--- a/internal/runner/attempt.go
+++ b/internal/runner/attempt.go
@@ -1,0 +1,47 @@
+package runner
+
+import "time"
+
+var (
+	timeFunc  = time.Now
+	sleepFunc = time.Sleep
+)
+
+type attemptStrategy struct {
+	interval time.Duration // interval between each try in milliseconds
+	retries  int           // number of retries for attempt
+}
+
+type attempt struct {
+	strategy attemptStrategy
+	lastTime time.Time
+	count    int // number of attempted retries
+}
+
+func newAttempt(rcount, interval int) *attempt {
+	return &attempt{
+		strategy: attemptStrategy{
+			retries:  rcount,
+			interval: time.Duration(interval) * time.Millisecond,
+		},
+	}
+}
+
+func (a *attempt) next() bool {
+	if a.shouldRetry() {
+		if !a.lastTime.IsZero() {
+			timeSince := timeFunc().Sub(a.lastTime)
+			if timeSince < a.strategy.interval {
+				sleepFunc(a.strategy.interval - timeSince)
+			}
+		}
+		a.lastTime = timeFunc()
+		a.count++
+		return true
+	}
+	return false
+}
+
+func (a *attempt) shouldRetry() bool {
+	return a.count < a.strategy.retries
+}

--- a/internal/scheduler/task.go
+++ b/internal/scheduler/task.go
@@ -3,9 +3,11 @@ package scheduler
 import "time"
 
 type Task struct {
-	ID        string            `json:"id"`
-	URL       string            `json:"url"`
-	ExecuteAt time.Time         `json:"execute_at"`
-	Headers   map[string]string `json:"headers"` // Custom headers
-	Payload   any               `json:"payload"` // Flexible payload
+	ID            string            `json:"id"`
+	URL           string            `json:"url"`
+	ExecuteAt     time.Time         `json:"execute_at"`
+	Headers       map[string]string `json:"headers"` // Custom headers
+	Payload       any               `json:"payload"` // Flexible payload
+	Retries       int               `json:"retries"`
+	RetryInterval int               `json:"retry_interval"` // milliseconds
 }


### PR DESCRIPTION
Hey, I stumbled upon this project yesterday - it actually helps a lot with my problems, thanks for this 😅 

I noticed the scheduler didn't currently support retrying requests when unexpected failures occur, so I added a simple retry mechanism using a retry count and an interval between retry attempts.

Looking forward for your feedback!